### PR TITLE
Investigate private repo template interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,33 @@ e.g. to try [this summarize.yaml](https://github.com/simonw/llm-templates/blob/m
 ```bash
 curl -L https://llm.datasette.io/ | llm -t gh:simonw/summarize
 ```
+
+### Private Repository Support
+
+This plugin supports loading templates from private GitHub repositories. To use this feature, you need to provide a GitHub personal access token via environment variable:
+
+```bash
+export GITHUB_TOKEN="your-github-token"
+# or
+export LLM_GITHUB_TOKEN="your-github-token"
+```
+
+Then you can use templates from private repositories just like public ones:
+
+```bash
+llm -t gh:yourorg/private-repo/template-name
+```
+
+#### Creating a GitHub Token
+
+1. Go to [GitHub Settings > Developer settings > Personal access tokens](https://github.com/settings/tokens)
+2. Click "Generate new token" (classic or fine-grained)
+3. For classic tokens: Select the `repo` scope
+4. For fine-grained tokens: Grant "Contents" repository permissions for the repositories you want to access
+5. Copy the token and set it as an environment variable
+
+**Security Note**: Keep your GitHub token secure and never commit it to version control.
+
 ## Development
 
 To set up this plugin locally, first checkout the code. Then create a new virtual environment:

--- a/llm_templates_github.py
+++ b/llm_templates_github.py
@@ -1,6 +1,8 @@
 from llm import Template, hookimpl
 import yaml
 import httpx
+import os
+import base64
 
 
 @hookimpl
@@ -14,6 +16,8 @@ def github_template_loader(template_path: str) -> Template:
 
     Format: username/repo/template_name (without the .yaml extension)
       or username/template_name which means username/llm-templates/template_name
+    
+    Supports private repositories via GITHUB_TOKEN or LLM_GITHUB_TOKEN environment variable.
     """
     parts = template_path.split("/")
     if len(parts) == 2:
@@ -24,18 +28,51 @@ def github_template_loader(template_path: str) -> Template:
         )
 
     username, repo, template_name = parts
-
-    # Fetch template directly from GitHub
+    
+    # Check for GitHub token in environment
+    github_token = os.environ.get("GITHUB_TOKEN") or os.environ.get("LLM_GITHUB_TOKEN")
+    
+    # Prepare headers if token is available
+    headers = {}
+    if github_token:
+        headers["Authorization"] = f"Bearer {github_token}"
+    
+    # Try raw.githubusercontent.com first (works for public repos and private with token)
     path = f"{template_name}.yaml"
-    url = f"https://raw.githubusercontent.com/{username}/{repo}/main/{path}"
-
+    raw_url = f"https://raw.githubusercontent.com/{username}/{repo}/main/{path}"
+    
     try:
-        response = httpx.get(url)
+        response = httpx.get(raw_url, headers=headers, follow_redirects=True)
+        
         if response.status_code == 200:
             content = response.text
+        elif response.status_code == 404 and github_token:
+            # If raw URL fails with token, try GitHub API
+            api_url = f"https://api.github.com/repos/{username}/{repo}/contents/{path}"
+            api_response = httpx.get(api_url, headers=headers)
+            
+            if api_response.status_code == 200:
+                api_data = api_response.json()
+                # GitHub API returns base64-encoded content
+                content = base64.b64decode(api_data["content"]).decode("utf-8")
+            else:
+                raise ValueError(
+                    f"Template '{template_name}' not found in repository '{username}/{repo}' "
+                    f"(API returned HTTP {api_response.status_code})"
+                )
+        elif response.status_code == 404:
+            raise ValueError(
+                f"Template '{template_name}' not found in repository '{username}/{repo}'. "
+                f"If this is a private repository, set GITHUB_TOKEN or LLM_GITHUB_TOKEN environment variable."
+            )
+        elif response.status_code == 401:
+            raise ValueError(
+                f"Authentication failed for repository '{username}/{repo}'. "
+                f"Please check your GitHub token."
+            )
         else:
             raise ValueError(
-                f"Template '{template_name}' not found in repository '{username}/{repo}' (HTTP {response.status_code})"
+                f"Failed to fetch template from '{username}/{repo}' (HTTP {response.status_code})"
             )
     except httpx.HTTPError as ex:
         raise ValueError(f"Failed to fetch template from GitHub: {ex}")

--- a/tests/test_templates_github.py
+++ b/tests/test_templates_github.py
@@ -2,6 +2,9 @@ import pytest
 from llm_templates_github import github_template_loader
 from llm import Template
 import yaml
+import os
+import json
+import base64
 
 
 @pytest.mark.parametrize(
@@ -65,3 +68,133 @@ def test_github_loader_success(
         assert template.prompt == yaml_content_dict
         assert template.system is None  # Assuming default is None
         assert template.model is None  # Assuming default is None
+
+
+def test_private_repo_without_token(httpx_mock):
+    """Test that accessing private repo without token gives helpful error."""
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/org/private-repo/main/template.yaml",
+        method="GET",
+        status_code=404
+    )
+    
+    with pytest.raises(ValueError) as exc_info:
+        github_template_loader("org/private-repo/template")
+    
+    assert "private repository" in str(exc_info.value).lower()
+    assert "GITHUB_TOKEN" in str(exc_info.value)
+
+
+def test_private_repo_with_token_raw_url(httpx_mock, monkeypatch):
+    """Test successful access to private repo via raw URL with token."""
+    monkeypatch.setenv("GITHUB_TOKEN", "test-token-123")
+    
+    template_content = "Private template content"
+    
+    def custom_matcher(request):
+        return (
+            request.url == "https://raw.githubusercontent.com/org/private-repo/main/secret.yaml"
+            and request.headers.get("Authorization") == "Bearer test-token-123"
+        )
+    
+    httpx_mock.add_response(
+        match_headers={"Authorization": "Bearer test-token-123"},
+        url="https://raw.githubusercontent.com/org/private-repo/main/secret.yaml",
+        text=template_content,
+        status_code=200
+    )
+    
+    template = github_template_loader("org/private-repo/secret")
+    
+    assert template.name == "org/private-repo/secret"
+    assert template.prompt == template_content
+
+
+def test_private_repo_with_token_api_fallback(httpx_mock, monkeypatch):
+    """Test fallback to GitHub API when raw URL fails."""
+    monkeypatch.setenv("LLM_GITHUB_TOKEN", "test-token-456")
+    
+    template_content = {"prompt": "API template", "system": "Be helpful"}
+    yaml_content = yaml.dump(template_content)
+    encoded_content = base64.b64encode(yaml_content.encode()).decode()
+    
+    # First request to raw URL fails
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/org/private/main/api-template.yaml",
+        match_headers={"Authorization": "Bearer test-token-456"},
+        status_code=404
+    )
+    
+    # Second request to API succeeds
+    api_response = {
+        "content": encoded_content,
+        "encoding": "base64",
+        "name": "api-template.yaml"
+    }
+    
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/org/private/contents/api-template.yaml",
+        match_headers={"Authorization": "Bearer test-token-456"},
+        json=api_response,
+        status_code=200
+    )
+    
+    template = github_template_loader("org/private/api-template")
+    
+    assert template.name == "org/private/api-template"
+    assert template.prompt == template_content["prompt"]
+    assert template.system == template_content["system"]
+
+
+def test_authentication_failure(httpx_mock, monkeypatch):
+    """Test handling of authentication failures."""
+    monkeypatch.setenv("GITHUB_TOKEN", "invalid-token")
+    
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/org/repo/main/template.yaml",
+        status_code=401
+    )
+    
+    with pytest.raises(ValueError) as exc_info:
+        github_template_loader("org/repo/template")
+    
+    assert "Authentication failed" in str(exc_info.value)
+
+
+def test_both_env_vars(httpx_mock, monkeypatch):
+    """Test that GITHUB_TOKEN takes precedence over LLM_GITHUB_TOKEN."""
+    monkeypatch.setenv("GITHUB_TOKEN", "primary-token")
+    monkeypatch.setenv("LLM_GITHUB_TOKEN", "secondary-token")
+    
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/user/repo/main/test.yaml",
+        match_headers={"Authorization": "Bearer primary-token"},
+        text="test content",
+        status_code=200
+    )
+    
+    template = github_template_loader("user/repo/test")
+    assert template.prompt == "test content"
+
+
+def test_api_failure_with_token(httpx_mock, monkeypatch):
+    """Test proper error when both raw and API URLs fail."""
+    monkeypatch.setenv("GITHUB_TOKEN", "test-token")
+    
+    # Raw URL fails
+    httpx_mock.add_response(
+        url="https://raw.githubusercontent.com/org/repo/main/missing.yaml",
+        status_code=404
+    )
+    
+    # API also fails
+    httpx_mock.add_response(
+        url="https://api.github.com/repos/org/repo/contents/missing.yaml",
+        status_code=404
+    )
+    
+    with pytest.raises(ValueError) as exc_info:
+        github_template_loader("org/repo/missing")
+    
+    assert "not found" in str(exc_info.value).lower()
+    assert "API returned HTTP 404" in str(exc_info.value)


### PR DESCRIPTION
Add support for fetching templates from private GitHub repositories.

---
<a href="https://cursor.com/background-agent?bcId=bc-ce1393eb-5106-4544-a0bc-d92372a3a197">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ce1393eb-5106-4544-a0bc-d92372a3a197">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>